### PR TITLE
Add link to login and new issues in instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,13 +5,18 @@
 ## Usage
 
 The easiest way to update this website is to edit a document directly on github.
-Go to the file that you wish to change make your changes and then click on the pen icon and begin editing.
+[Log in](https://github.com/login) to github and o to the file that you wish to 
+change make your changes and then click on the pen icon and begin editing.
 When you are happy with the edit, click on the green button "Commit changes".
 You will be prompted to write a commit message, but for simple changes you can accept the default that is already filled in.
 Make sure that you commit directly in the main branch (the default option) and click on commit changes once more.
-That is it!
+**That is it!**
+
 A workflow should now be triggered that updates the websites.
-It can take a few minutes for your changes to appear and do not forget to refresh the site.
+
+It can take a few minutes for your changes to appear and do not forget to refresh your browser.
+If it takes more than a few minutes for the change to occur, try loading the page in another browser before 
+[reporting the issue](https://github.com/swinnoproject/website/issues/new).
 
 ### Example: Mangaging Team Member Pages
 


### PR DESCRIPTION
Added a small clarification that should log in to github first (provided the link).
As well as a link to creating a new issue, should something occur.