### PR TITLE
Remove alumni from team page

### DIFF
--- a/_quarto.yml
+++ b/_quarto.yml
@@ -27,7 +27,7 @@ website:
   page-footer:
     background: "#161324"
     left: |
-      Copyright &copy;  2023 [SWINNO Project]()
+      Copyright &copy;  2024 [SWINNO Project]()
     # center:
     #     - href: https://github.com/swinnoproject
     #       icon: github

--- a/team.qmd
+++ b/team.qmd
@@ -51,7 +51,3 @@ listing:
 :::{#affiliated}
 :::
 
-## Alumni
-
-:::{#alumni}
-:::


### PR DESCRIPTION
The idea is good, but as is we only have one person listed with the start and end dates of "YYYY"